### PR TITLE
Cleaning up the FlowcellRunMetricsParser module and adjust to X10

### DIFF
--- a/qc_parsers.py
+++ b/qc_parsers.py
@@ -141,6 +141,7 @@ class FlowcellRunMetricsParser():
         return new_metrics
 
     def _html_tables_to_lists_of_tuples(self, html):
+        html = open(html,'r')
         bs = BeautifulSoup(html)
         metrics = {}
         keys = []

--- a/qc_parsers.py
+++ b/qc_parsers.py
@@ -156,7 +156,7 @@ class FlowcellRunMetricsParser():
                     values = map(lambda v: v.text, row.findChildren('td'))
                     if len(values)==len(keys):
                         metrics[header].append(zip(keys, values))
-    return metrics
+        return metrics
 
 
 #html= open('laneBarcode.html','r')

--- a/qc_parsers.py
+++ b/qc_parsers.py
@@ -133,9 +133,11 @@ class FlowcellRunMetricsParser():
         metrics = self._html_tables_to_lists_of_tuples(html_file)    
         new_metrics = {}
         for header, table in metrics.items():
+            print header
             new_metrics[header] = []
             for sample in table:
                 new_metrics[header].append(dict(sample))
+        print new_metrics
         return new_metrics
 
     def _html_tables_to_lists_of_tuples(self, html):

--- a/qc_parsers.py
+++ b/qc_parsers.py
@@ -162,8 +162,3 @@ class FlowcellRunMetricsParser():
         return metrics
 
 
-#html= open('laneBarcode.html','r')
-#l=html_tables_to_dicts(html)
-
-#html= open('Demultiplex_Stats.htm','r')
-#D=html_tables_to_dicts(html)

--- a/scilifelab_parsers/qc/qc.py
+++ b/scilifelab_parsers/qc/qc.py
@@ -133,11 +133,9 @@ class FlowcellRunMetricsParser():
         metrics = self._html_tables_to_lists_of_tuples(html_file)    
         new_metrics = {}
         for header, table in metrics.items():
-            print header
             new_metrics[header] = []
             for sample in table:
                 new_metrics[header].append(dict(sample))
-        print new_metrics
         return new_metrics
 
     def _html_tables_to_lists_of_tuples(self, html):

--- a/scilifelab_parsers/qc/qc.py
+++ b/scilifelab_parsers/qc/qc.py
@@ -150,13 +150,19 @@ class FlowcellRunMetricsParser():
                 header = header.text.replace(' ','_')
             if header not in metrics.keys():
                 metrics[header] = []
-            if not metrics[header]: 
-                for row in table.findChildren('tr'):
+            if not metrics[header]: # Dont overwrite table list if its already set
+                for row in table.findChildren('tr'): # Table --> list of dicts 
                     if row.findChildren('th'):
-                        keys = map(lambda v: v.text, row.findChildren('th')) 
-                    values = map(lambda v: v.text, row.findChildren('td'))
+                        keys = map(lambda v: v.text, row.findChildren('th')) # table headers --> keys 
+                    values = map(lambda v: v.text, row.findChildren('td')) # table rows --> values
                     if len(values)==len(keys):
                         metrics[header].append(zip(keys, values))
         return metrics
+
+    def parse_laneBarcode_html(self, html_file):
+        metrics = self._html_tables_to_lists_of_tuples(html_file)
+        new_metrics = {}
+
+
 
 


### PR DESCRIPTION
This will also make it more easy to adjust the code so that it later can handle the X10 html output files. 

The _html_tables_to_lists_of_tuples() function can pars both Demultiplex_Stats.htm files generated by HiSeq/MiSeq and laneBarcode.html files generated by the new X10 machines.
